### PR TITLE
Fix - Text variants not working correctly on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v7.0.1 (Unreleased)
+
+### Fixed
+
+-   Text variants not working correctly on Android [89](https://github.com/etn-ccis/blui-react-native-themes/issues/89).
+
 ## v7.0.0 (January 12, 2024)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ import * as BLUIThemes from '@brightlayer-ui/react-native-themes';
 </ThemeProvider>
 ```
 
-
 ### React Native Paper Components Style Override
 
 This Document contains a set of style overrides in components around various [React Native Paper](https://callstack.github.io/react-native-paper/index.html) components.
@@ -75,6 +74,20 @@ const theme = useExtendedTheme();
 <Button mode="contained" style={{ backgroundColor: theme.colors.onOrangeFilledContainer }}>
     Label
 </Button>
+```
+
+## Changing fontWeight of a Text Element
+
+When you need to change the `fontWeight` of a `Text` element in your application, it's important to note that it should be done through the `fontFamily` property rather than the `fontWeight` property.
+
+The `fontFamily` property allows you to specify the font and its weight. By using the appropriate font family that supports the desired weight, you can achieve the desired fontWeight effect.
+
+For example, if you want to set the fontWeight to "bold", you can use a font family that includes a bold variant, such as:
+
+```tsx
+<Text variant={'headlineLarge'} style={{ fontFamily: 'OpenSans-Bold' }}>
+    headlineLarge
+</Text>
 ```
 
 ### Upgrading from version 6 -> 7

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/react-native-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "description": "React Native themes for Brightlayer UI applications",
     "main": "./dist/index.js",
     "scripts": {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,103 +1,87 @@
 import { Platform } from 'react-native';
 
 import { MD3Theme, useTheme } from 'react-native-paper';
-import { MD3Type, MD3Typescale } from 'react-native-paper/lib/typescript/types';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 
 export const fontConfig = {
     displaySmall: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
         fontSize: 36,
-        lineHeight: 45,
+        lineHeight: 48,
     },
     displayMedium: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
         fontSize: 45,
         lineHeight: 56,
     },
     displayLarge: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
-        fontSize: 54,
-        lineHeight: 68,
-        letterSpacing: 1,
+        fontSize: 57,
+        lineHeight: 72,
+        letterSpacing: -0.25,
     },
     headlineSmall: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '500' as const,
         fontSize: 24,
         lineHeight: 32,
     },
     headlineMedium: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '500' as const,
-        fontSize: 27,
-        lineHeight: 40,
+        fontSize: 28,
+        lineHeight: 36,
     },
     headlineLarge: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '500' as const,
         fontSize: 32,
         lineHeight: 40,
     },
     titleSmall: {
-        fontFamily: 'OpenSans-Regular',
-        fontWeight: '600' as const,
+        fontFamily: 'OpenSans-SemiBold',
         fontSize: 14,
         lineHeight: 20,
         letterSpacing: 0.1,
     },
     titleMedium: {
-        fontFamily: 'OpenSans-Regular',
-        fontWeight: '600' as const,
+        fontFamily: 'OpenSans-SemiBold',
         fontSize: 16,
         lineHeight: 24,
         letterSpacing: 0.15,
     },
     titleLarge: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
         fontSize: 22,
         lineHeight: 28,
     },
     labelSmall: {
         fontFamily: 'OpenSans-SemiBold',
-        fontWeight: '600' as const,
         fontSize: 11,
         lineHeight: 16,
         letterSpacing: 0.5,
     },
     labelMedium: {
         fontFamily: 'OpenSans-SemiBold',
-        fontWeight: '600' as const,
         fontSize: 12,
         lineHeight: 16,
         letterSpacing: 0.2,
     },
     labelLarge: {
         fontFamily: 'OpenSans-SemiBold',
-        fontWeight: '600' as const,
         fontSize: 14,
         lineHeight: 20,
         letterSpacing: 0.1,
     },
     bodySmall: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
         fontSize: 12,
         lineHeight: 16,
     },
     bodyMedium: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
         fontSize: 14,
         lineHeight: 20,
     },
     bodyLarge: {
         fontFamily: 'OpenSans-Regular',
-        fontWeight: '400' as const,
         fontSize: 16,
         lineHeight: 24,
         letterSpacing: 0.15,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes [89](https://github.com/etn-ccis/blui-react-native-themes/issues/89) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Update fontsize, line height, font family as per [figma](https://www.figma.com/file/Nydz8n8HBj6U3ZtULja3gD/%F0%9F%92%AB-Brightlayer-UI-Tokens-%2B-Components-(in-Material-Design-3)?type=design&node-id=6-54&mode=design&t=AEFpRmXTWIBDSlbu-0)
- Update listItemTag https://github.com/etn-ccis/blui-react-native-component-library/pull/554
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
Android
<img width="522" alt="Screenshot 2024-03-28 at 6 23 13 PM" src="https://github.com/etn-ccis/blui-react-native-component-library/assets/133877691/900c5e04-1ec0-405d-929a-ca7fd97b218a">
-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- 
